### PR TITLE
fix: upgrade Google Analytics from UA to GA4

### DIFF
--- a/index.html
+++ b/index.html
@@ -79,13 +79,13 @@
 
 <body id="page-top" data-spy="scroll" data-target=".navbar-fixed-top" data-offset="200">
  <!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=UA-9932775-2"></script>
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-ZPWRYB81S5"></script>
 <script>
   window.dataLayer = window.dataLayer || [];
   function gtag(){dataLayer.push(arguments);}
   gtag('js', new Date());
 
-  gtag('config', 'UA-9932775-2');
+  gtag('config', 'G-ZPWRYB81S5');
 </script>
 
   <!-- Navigation -->


### PR DESCRIPTION
## Summary
- Replace legacy Universal Analytics tag `UA-9932775-2` with GA4 measurement ID `G-ZPWRYB81S5`

🤖 Generated with [Claude Code](https://claude.com/claude-code)